### PR TITLE
Relocate the fetching of default table columns so col filters function

### DIFF
--- a/lib/tribe-columns.class.php
+++ b/lib/tribe-columns.class.php
@@ -56,6 +56,11 @@ class Tribe_Columns {
 		$this->add_actions_and_filters();
 
 		$this->url = trailingslashit( plugins_url( '', __FILE__ ) );
+
+		// get the headers for the table
+		$this->load_list_table();
+		$list = new WP_Posts_List_Table();
+		$this->headers = $list->get_columns();
 	}
 
 	// PUBLIC API METHODS
@@ -357,14 +362,7 @@ class Tribe_Columns {
 				$headers = array('cb' => '<input type="checkbox" />');
 			}
 			else {
-				// Cause infinite loops get boring after a while
-				remove_filter( 'manage_'.$this->post_type.'_posts_columns', array($this, 'column_headers'));
-				$this->load_list_table();
-
-				$list = new WP_Posts_List_Table();
-				$headers = $list->get_columns();
-
-				add_filter( 'manage_'.$this->post_type.'_posts_columns', array($this, 'column_headers'));
+				$headers = $this->headers;
 			}
 			foreach ( $this->columns as $key => $value ) {
 				$headers[$key] = $value['name'];


### PR DESCRIPTION
When a user wishes to filter out columns from a List Table pragmatically via `manage_{posttype}_posts_columns`, the List Table that is manipulated by Advanced Post Manager doesn't respect the filter due to the location/timing of header fetching in the plugin. We're unhooking a filter [here](https://github.com/moderntribe/advanced-post-manager/blob/release/119/lib/tribe-columns.class.php#L361), grabbing columns anew, and then re-hooking the filter. 

This fix relocates the column header fetching to the constructor when our column class is initialized.

See: https://central.tri.be/issues/37961