### PR TITLE
Use gulp rather than grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# How to contribute
+
+We happily review/accept third-party Pull Requests. To help get your
+patches adopted into our plugins, there's a few bits of info that are
+worth knowing.
+
+## Standards
+
+We have a set of [coding standards](http://moderntribe.github.io/products-engineering/)
+that we follow and encourage others to follow as well. When you submit
+Pull Requests, you'll probably notice a friendly bot - `tr1b0t` - that
+comments on your PR and suggests changes. Be gentle with him, he's only
+trying to help. He also has a pretty good idea about what we'd like to
+see in terms of code formatting, so don't ignore him.
+
+## Gulp
+
+We compress/uglify our CSS and JS files using [Gulp](http://gulpjs.com/)
+via our very own [`product-taskmaster`](https://github.com/moderntribe/product-taskmaster)
+repo - which is a collection of gulp tasks. Here's how you get rolling
+with that.
+
+### Prerequisites
+
+#### Install Node.js
+
+If you don't already have Node.js installed, please do so first:
+
+[Download Node.js](http://nodejs.org/download/)
+
+#### Install Gulp
+
+The only requirement for Gulp is the Gulp CLI (Command Line Utility). If
+you don't already have that installed, install it globally. You can do
+that with the npm `-g` flag.
+
+```
+npm install -g gulp-cli
+```
+
+#### Install all the things
+
+With all of those in place, simply run:
+
+```
+npm install
+```
+
+If you run into any issues with some of the tasks down the road, run npm
+rebuild and try again.
+
+```
+npm rebuild
+```
+
+### Using Gulp
+
+Our gulp tasks are documented in our [product-taskmanager README](https://github.com/moderntribe/product-taskmaster#gulp-tasks).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,7 @@
+/**
+ * This is a simple gulp file that loads gulp tasks from a tasks directory.
+ * Whee.
+ */
+var gulp = require( 'gulp' );
+
+require( 'product-taskmaster' )( gulp );

--- a/package-whitelist.json
+++ b/package-whitelist.json
@@ -1,0 +1,11 @@
+[
+  "tribe-apm.php",
+  "scratch.php",
+  "docs/**/*",
+  "lang/**/*",
+  "lib/**/*",
+  "resources/**/*",
+  "views/**/*",
+  "readme.txt",
+  "screenshot*.png"
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "advanced-post-manager",
+  "version": "4.1.0rc1",
+  "repository": "git@github.com:moderntribe/advanced-post-manager.git",
+  "_zipname": "advanced-post-manager",
+  "_zipfoldername": "advanced-post-manager",
+  "_resourcepath": "src/resources",
+  "_domainPath": "lang",
+  "_textDomain": "tribe-apm",
+  "_glotPressUrl": "http://translations.theeventscalendar.com",
+  "_glotPressSlug": "tribe-apm",
+  "_glotPressFileFormat": "%textdomain%-%wp_locale%.%format%",
+  "_glotPressFormats": [
+    "po",
+    "mo"
+  ],
+  "_glotPressFilter": {
+    "translation_sets": false,
+    "minimum_percentage": 30,
+    "waiting_strings": false
+  },
+  "engines": {
+    "node": "0.10.30",
+    "npm": "1.4.23"
+  },
+  "devDependencies": {
+    "archiver": "^0.10.1",
+    "glob": "~4.0.5",
+    "gulp": "^3.9.1",
+    "product-taskmaster": "git+https://github.com/moderntribe/product-taskmaster.git",
+    "require-dir": "^0.3.0"
+  }
+}


### PR DESCRIPTION
This PR removes the `dev/` directory completely, moves `package.json` to the main directory, adds a `gulpfile.js`.  A couple of things were added to `package.json` to make this possible:

1. GlotPress properties for the `gulp glotpress` task
1. A `devDependency` on our public [product-taskmaster repository](https://github.com/moderntribe/product-taskmaster)

The key tasks (as the product-taskmaster README says):

* `gulp` - this compresses CSS and JS
* `gulp watch` - this watches for changes in CSS and JS files,
* compresses them, and communicates the file changes to livereload
* `gulp package --branch <some-branch>` - This packages up a specific
* branch in the repository by compressing files, updating submodules,
* pulling the latest GlotPress files, and zipping based on a
* `package-whitelist.json` file.

See: https://central.tri.be/issues/44701