### PR TITLE
fix broke support for `wysiwyg` field

### DIFF
--- a/lib/tribe-meta-box.php
+++ b/lib/tribe-meta-box.php
@@ -40,7 +40,6 @@ class Tribe_Meta_Box {
 		$this->check_field_color();
 		$this->check_field_date();
 		$this->check_field_time();
-		$this->check_field_wysiwyg();
 
 		// load common js, css files
 		// must enqueue for all pages as we need js for the media upload, too
@@ -243,13 +242,6 @@ class Tribe_Meta_Box {
 		}
 	}
 
-	// Check field WYSIWYG
-	public function check_field_wysiwyg() {
-		if ( $this->has_field( 'wysiwyg' ) && self::is_edit_page() ) {
-			add_action( 'admin_print_footer_scripts', 'wp_tiny_mce', 25 );
-		}
-	}
-
 	/******************** END OTHER FIELDS **********************/
 
 	/******************** BEGIN META BOX PAGE **********************/
@@ -366,7 +358,12 @@ class Tribe_Meta_Box {
 
 	public function show_field_wysiwyg( $field, $meta ) {
 		$this->show_field_begin( $field, $meta );
-		echo "<textarea class='tribe-wysiwyg theEditor large-text' name='{$field['meta']}' id='{$field['meta']}' cols='60' rows='10'>$meta</textarea>";
+		$content  = get_post_meta( get_the_ID(), $field['meta'], true );
+		$content  = empty( $content ) || ! is_string( $content ) ? '' : $content;
+		$settings = array(
+			'media_buttons' => isset( $field['media_buttons'] ) ? (bool) $field['meta_buttons'] : false,
+		);
+		wp_editor( $content, $field['meta'], $settings );
 		$this->show_field_end( $field, $meta );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,10 @@ Our Premium Plugins:
 
 == Changelog ==
 
+= [4.2.2] unreleased =
+
+* Fix - `wysiwyg` field type in meta box will now render a TinyMCE editor and not a text area [15185]
+
 = [4.2] 2016-06-22 =
 
 * Fix - Avoid errors and UI cruft when deactivating a plugin that added custom filters in use


### PR DESCRIPTION
Ticket https://central.tri.be/issues/15185

This PR makes the `wysiwyg` field type output a TinyMCE field and save its contents.