### PR TITLE
Fix outdated code standards link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ worth knowing.
 
 ## Standards
 
-We have a set of [coding standards](http://the-events-calendar.github.io/products-engineering/)
+We have a set of [coding standards](https://docs.theeventscalendar.com/developer/code-standards/)
 that we follow and encourage others to follow as well. When you submit
 Pull Requests, you'll probably notice a friendly bot - `tr1b0t` - that
 comments on your PR and suggests changes. Be gentle with him, he's only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,4 +55,4 @@ npm rebuild
 
 ### Using Gulp
 
-Our gulp tasks are documented in our [product-taskmanager README](https://github.com/the-events-calendar/product-taskmaster#gulp-tasks).
+Our gulp tasks are documented in our [product-taskmaster README](https://github.com/the-events-calendar/product-taskmaster#gulp-tasks).


### PR DESCRIPTION
### 🎫 Ticket

https://linear.app/nexcess/issue/SMTNC-1451/fix-outdated-code-standards-links-in-contributingmd

### 🗒️ Description

This pull request updates the link to the coding standards in the `CONTRIBUTING.md` file to point to the correct documentation site.

- Updated the coding standards link in `CONTRIBUTING.md` from the old GitHub Pages URL to the new URL: `https://docs.theeventscalendar.com/developer/code-standards/`

### ✔️ Checklist
- [x] Automated code review comments are addressed.